### PR TITLE
feat: 🌱 Crear funcionalidad para gestionar aspersores

### DIFF
--- a/src/TechNovaLab.Irrigo.Api/Endpoints/Sprinklers/CreateSprinkler.cs
+++ b/src/TechNovaLab.Irrigo.Api/Endpoints/Sprinklers/CreateSprinkler.cs
@@ -1,0 +1,35 @@
+﻿using MediatR;
+using TechNovaLab.Irrigo.Api.Extensions;
+using TechNovaLab.Irrigo.Api.Infrastructure;
+using TechNovaLab.Irrigo.Application.Features.SprinklerManagement.CreateSprinkler;
+using TechNovaLab.Irrigo.Domain.Entities.Users;
+using TechNovaLab.Irrigo.SharedKernel.Core;
+
+namespace TechNovaLab.Irrigo.Api.Endpoints.Sprinklers
+{
+    internal sealed class CreateSprinkler : IEndpoint
+    {
+        public sealed record Request(
+            string Name, 
+            int? SprinklerGroupId, 
+            double IrrigationCapacityPerMinute);
+
+        public void MapEndpoint(IEndpointRouteBuilder app)
+        {
+            app.MapPost("sprinklers/create", async (Request request, ISender sender, CancellationToken cancellationToken) =>
+            {
+                var command = new CreateSprinklerCommand(
+                    request.Name,
+                    request.SprinklerGroupId,
+                    request.IrrigationCapacityPerMinute);
+
+                Result<SprinklerResponse> result = await sender.Send(command, cancellationToken);
+
+                return result.Match(Results.Ok, CustomResults.Problem);
+            })
+            .HasRole(Role.Contributor)
+            .HasPermission("users:access")
+            .WithTags(Tags.Sprinklers);
+        }
+    }
+}

--- a/src/TechNovaLab.Irrigo.Api/Endpoints/Tags.cs
+++ b/src/TechNovaLab.Irrigo.Api/Endpoints/Tags.cs
@@ -3,6 +3,7 @@
     public static class Tags
     {
         public const string HealthChecks = "HealthChecks";
+        public const string Sprinklers = "Sprinklers";
         public const string Users = "Users";
     }
 }

--- a/src/TechNovaLab.Irrigo.Api/Endpoints/Users/GetByEmail.cs
+++ b/src/TechNovaLab.Irrigo.Api/Endpoints/Users/GetByEmail.cs
@@ -20,7 +20,7 @@ namespace TechNovaLab.Irrigo.Api.Endpoints.Users
                 return result.Match(Results.Ok, CustomResults.Problem);
             })
             .HasRole(Role.Member)
-            .HasPermission("users:read/write")
+            .HasPermission("users:access")
             .WithTags(Tags.Users);
         }
     }

--- a/src/TechNovaLab.Irrigo.Application/Features/SprinklerManagement/CreateSprinkler/CreateSprinklerCommand.cs
+++ b/src/TechNovaLab.Irrigo.Application/Features/SprinklerManagement/CreateSprinkler/CreateSprinklerCommand.cs
@@ -1,0 +1,10 @@
+﻿using TechNovaLab.Irrigo.Application.Abstractions.Messaging;
+
+namespace TechNovaLab.Irrigo.Application.Features.SprinklerManagement.CreateSprinkler
+{
+    public sealed record CreateSprinklerCommand(
+        string Name, 
+        int? SprinklerGroupId,
+        double IrrigationCapacityPerMinute) : ICommand<SprinklerResponse>;
+    
+}

--- a/src/TechNovaLab.Irrigo.Application/Features/SprinklerManagement/CreateSprinkler/CreateSprinklerCommandHandler.cs
+++ b/src/TechNovaLab.Irrigo.Application/Features/SprinklerManagement/CreateSprinkler/CreateSprinklerCommandHandler.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.EntityFrameworkCore;
+using TechNovaLab.Irrigo.Application.Abstractions.Data;
+using TechNovaLab.Irrigo.Application.Abstractions.Messaging;
+using TechNovaLab.Irrigo.Domain.Entities.Sprinklers;
+using TechNovaLab.Irrigo.Domain.Errors;
+using TechNovaLab.Irrigo.Domain.Repositories;
+using TechNovaLab.Irrigo.SharedKernel.Core;
+
+namespace TechNovaLab.Irrigo.Application.Features.SprinklerManagement.CreateSprinkler
+{
+    internal sealed class CreateSprinklerCommandHandler(
+        IRepository repository, 
+        IUnitOfWork unitOfWork) : ICommandHandler<CreateSprinklerCommand, SprinklerResponse>
+    {
+        public async Task<Result<SprinklerResponse>> Handle(CreateSprinklerCommand request, CancellationToken cancellationToken)
+        {
+            var anySprinkler = await repository
+                .Get<Sprinkler>()
+                .AnyAsync(x => x.Name == request.Name, cancellationToken);
+
+            if(anySprinkler)
+            {
+                return Result.Failure<SprinklerResponse>(SprinklerErrors.NameNotUnique);
+            }
+
+            var sprinkler = new Sprinkler
+            {
+                PublicId = Guid.NewGuid(),
+                Name = request.Name,
+                IrrigationCapacityPerMinute = request.IrrigationCapacityPerMinute,
+            };
+
+            await repository.AddAsync(sprinkler, cancellationToken);
+            await unitOfWork.CompleteAsync(cancellationToken);
+
+            return new SprinklerResponse(
+                sprinkler.PublicId, 
+                sprinkler.Name, 
+                sprinkler.SprinklerGroupId, 
+                sprinkler.IrrigationCapacityPerMinute);            
+        }
+    }
+    
+}

--- a/src/TechNovaLab.Irrigo.Application/Features/SprinklerManagement/CreateSprinkler/SprinklerResponse.cs
+++ b/src/TechNovaLab.Irrigo.Application/Features/SprinklerManagement/CreateSprinkler/SprinklerResponse.cs
@@ -1,0 +1,9 @@
+﻿namespace TechNovaLab.Irrigo.Application.Features.SprinklerManagement.CreateSprinkler
+{
+    public sealed record SprinklerResponse(
+        Guid PublicId,
+        string Name,
+        int? SprinklerGroupId,
+        double IrrigationCapacityPerMinute);
+    
+}

--- a/src/TechNovaLab.Irrigo.Domain/Errors/SprinklerErrors.cs
+++ b/src/TechNovaLab.Irrigo.Domain/Errors/SprinklerErrors.cs
@@ -1,0 +1,10 @@
+﻿using TechNovaLab.Irrigo.SharedKernel.Errors;
+
+namespace TechNovaLab.Irrigo.Domain.Errors
+{
+    public static class SprinklerErrors
+    {
+        public static readonly Error NameNotUnique = Error.Conflict(
+            "Sprinklers.NameNotUnique", "The provided name is not unique.");
+    }
+}


### PR DESCRIPTION

- Se ha implementado el endpoint para crear aspersores.
- Incluye el caso de uso correspondiente con validaciones básicas.
- Preparado para integración con la funcionalidad de grupos de aspersores en futuros desarrollos.