### PR TITLE
feat: 🌱 Implementar creación de tipos de cultivo

### DIFF
--- a/src/TechNovaLab.Irrigo.Api/Endpoints/Crops/CreateCropType.cs
+++ b/src/TechNovaLab.Irrigo.Api/Endpoints/Crops/CreateCropType.cs
@@ -1,0 +1,27 @@
+﻿using MediatR;
+using TechNovaLab.Irrigo.Api.Extensions;
+using TechNovaLab.Irrigo.Api.Infrastructure;
+using TechNovaLab.Irrigo.Application.Features.CropsManagement.CreateCropType;
+using TechNovaLab.Irrigo.SharedKernel.Core;
+
+namespace TechNovaLab.Irrigo.Api.Endpoints.Crops
+{
+    internal sealed class CreateCropType : IEndpoint
+    {
+        public sealed record Request(string Name, int WaterRequiredPerDay);
+
+        public void MapEndpoint(IEndpointRouteBuilder app)
+        {
+            app.MapPost("crops/create-crop-type", async (Request request, ISender sender, CancellationToken cancellationToken) =>
+            {
+                var command = new CreateCropTypeCommand(
+                    request.Name, 
+                    request.WaterRequiredPerDay);
+
+                Result<CropTypeResponse> result = await sender.Send(command, cancellationToken);
+
+                return result.Match(Results.Ok, CustomResults.Problem);
+            });
+        }
+    }
+}

--- a/src/TechNovaLab.Irrigo.Application/Features/CropsManagement/CreateCropType/CreateCropTypeCommand.cs
+++ b/src/TechNovaLab.Irrigo.Application/Features/CropsManagement/CreateCropType/CreateCropTypeCommand.cs
@@ -1,0 +1,8 @@
+﻿using TechNovaLab.Irrigo.Application.Abstractions.Messaging;
+
+namespace TechNovaLab.Irrigo.Application.Features.CropsManagement.CreateCropType
+{
+    public sealed record CreateCropTypeCommand(
+        string Name,
+        int WaterRequiredPerDay) : ICommand<CropTypeResponse>;
+}

--- a/src/TechNovaLab.Irrigo.Application/Features/CropsManagement/CreateCropType/CreateCropTypeCommandHandler.cs
+++ b/src/TechNovaLab.Irrigo.Application/Features/CropsManagement/CreateCropType/CreateCropTypeCommandHandler.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.EntityFrameworkCore;
+using TechNovaLab.Irrigo.Application.Abstractions.Data;
+using TechNovaLab.Irrigo.Application.Abstractions.Messaging;
+using TechNovaLab.Irrigo.Domain.Entities.Crops;
+using TechNovaLab.Irrigo.Domain.Errors;
+using TechNovaLab.Irrigo.Domain.Repositories;
+using TechNovaLab.Irrigo.SharedKernel.Core;
+
+namespace TechNovaLab.Irrigo.Application.Features.CropsManagement.CreateCropType
+{
+    internal sealed class CreateCropTypeCommandHandler(
+        IRepository repository,
+        IUnitOfWork unitOfWork) : ICommandHandler<CreateCropTypeCommand, CropTypeResponse>
+    {
+        public async Task<Result<CropTypeResponse>> Handle(CreateCropTypeCommand command, CancellationToken cancellationToken)
+        {
+            var anyCropType = await repository
+                .Get<CropType>()
+                .AnyAsync(x => x.Name == command.Name, cancellationToken);
+
+            if (anyCropType)
+            {
+                return Result.Failure<CropTypeResponse>(CropTypeErrors.NameNotUnique);
+            }
+
+            var cropType = new CropType
+            {
+                PublicId = Guid.NewGuid(),
+                Name = command.Name,
+                WaterRequiredPerDay = command.WaterRequiredPerDay,
+            };
+
+            await repository.AddAsync(cropType, cancellationToken);
+            await unitOfWork.CompleteAsync(cancellationToken);
+
+            return new CropTypeResponse(
+                cropType.PublicId,
+                cropType.Name,
+                cropType.WaterRequiredPerDay);
+        }
+    }
+}

--- a/src/TechNovaLab.Irrigo.Application/Features/CropsManagement/CreateCropType/CropTypeResponse.cs
+++ b/src/TechNovaLab.Irrigo.Application/Features/CropsManagement/CreateCropType/CropTypeResponse.cs
@@ -1,0 +1,7 @@
+﻿namespace TechNovaLab.Irrigo.Application.Features.CropsManagement.CreateCropType
+{
+    public sealed record CropTypeResponse(
+        Guid PublicId,
+        string Name,
+        int WaterRequiredPerDay);
+}

--- a/src/TechNovaLab.Irrigo.Domain/Errors/CropTypeErrors.cs
+++ b/src/TechNovaLab.Irrigo.Domain/Errors/CropTypeErrors.cs
@@ -1,0 +1,10 @@
+﻿using TechNovaLab.Irrigo.SharedKernel.Errors;
+
+namespace TechNovaLab.Irrigo.Domain.Errors
+{
+    public static class CropTypeErrors
+    {
+        public static readonly Error NameNotUnique = Error.Conflict(
+            "CropTypes.NameNotUnique", "The provided name is not unique.");
+    }
+}


### PR DESCRIPTION
- Se implementó el caso de uso para crear un tipo de cultivo.
- Se añadió el endpoint correspondiente para exponer la funcionalidad.
- Se definieron los tipos de errores asociados al caso de uso (e.g., validaciones, conflictos).
- Documentación del endpoint incluida en el archivo OpenAPI/Swagger.