### PR TITLE
feat: 🌱 implementar caso de uso y endpoint para crear jardinera

### DIFF
--- a/src/TechNovaLab.Irrigo.Api/Endpoints/Planters/CreatePlanter.cs
+++ b/src/TechNovaLab.Irrigo.Api/Endpoints/Planters/CreatePlanter.cs
@@ -1,0 +1,27 @@
+﻿using MediatR;
+using TechNovaLab.Irrigo.Api.Extensions;
+using TechNovaLab.Irrigo.Api.Infrastructure;
+using TechNovaLab.Irrigo.Application.Features.PlanterManagement.CreatePlanter;
+using TechNovaLab.Irrigo.SharedKernel.Core;
+
+namespace TechNovaLab.Irrigo.Api.Endpoints.Planters
+{
+    public sealed class CreatePlanter : IEndpoint
+    {
+        public sealed record Request(string Name, string Description);
+
+        public void MapEndpoint(IEndpointRouteBuilder app)
+        {
+            app.MapPost("planters/create-planter", async (Request request, ISender sender, CancellationToken cancellationToken) =>
+            {
+                var command = new CreatePlanterCommand(
+                    request.Name,
+                    request.Description);
+
+                Result<PlanterResponse> result = await sender.Send(command, cancellationToken);
+
+                return result.Match(Results.Ok, CustomResults.Problem);
+            });
+        }
+    }
+}

--- a/src/TechNovaLab.Irrigo.Application/Features/PlanterManagement/CreatePlanter/CreatePlanterCommand.cs
+++ b/src/TechNovaLab.Irrigo.Application/Features/PlanterManagement/CreatePlanter/CreatePlanterCommand.cs
@@ -1,0 +1,8 @@
+﻿using TechNovaLab.Irrigo.Application.Abstractions.Messaging;
+
+namespace TechNovaLab.Irrigo.Application.Features.PlanterManagement.CreatePlanter
+{
+    public sealed record CreatePlanterCommand(
+        string Name,
+        string Description) : ICommand<PlanterResponse>;
+}

--- a/src/TechNovaLab.Irrigo.Application/Features/PlanterManagement/CreatePlanter/CreatePlanterCommandHandler.cs
+++ b/src/TechNovaLab.Irrigo.Application/Features/PlanterManagement/CreatePlanter/CreatePlanterCommandHandler.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.EntityFrameworkCore;
+using TechNovaLab.Irrigo.Application.Abstractions.Data;
+using TechNovaLab.Irrigo.Application.Abstractions.Messaging;
+using TechNovaLab.Irrigo.Domain.Entities.Planters;
+using TechNovaLab.Irrigo.Domain.Errors;
+using TechNovaLab.Irrigo.Domain.Repositories;
+using TechNovaLab.Irrigo.SharedKernel.Core;
+
+namespace TechNovaLab.Irrigo.Application.Features.PlanterManagement.CreatePlanter
+{
+    internal sealed class CreatePlanterCommandHandler(
+        IRepository repository, 
+        IUnitOfWork unitOfWork) : ICommandHandler<CreatePlanterCommand, PlanterResponse>
+    {
+        public async Task<Result<PlanterResponse>> Handle(CreatePlanterCommand command, CancellationToken cancellationToken)
+        {
+            var anyPlanter = await repository
+                .Get<Planter>()
+                .AnyAsync(x => x.Name == command.Name, cancellationToken);
+
+            if(anyPlanter)
+            {
+                return Result.Failure<PlanterResponse>(PlanterErrors.NameNotUnique);
+            }
+
+            var planter = new Planter
+            {
+                PublicId = Guid.NewGuid(),
+                Name = command.Name,
+                Description = command.Description,
+            };
+
+            await repository.AddAsync(planter, cancellationToken);
+            await unitOfWork.CompleteAsync(cancellationToken);
+
+            return new PlanterResponse(
+                planter.PublicId,
+                planter.Name,
+                planter.Description);
+        }
+    }
+}

--- a/src/TechNovaLab.Irrigo.Application/Features/PlanterManagement/CreatePlanter/PlanterResponse.cs
+++ b/src/TechNovaLab.Irrigo.Application/Features/PlanterManagement/CreatePlanter/PlanterResponse.cs
@@ -1,0 +1,7 @@
+﻿namespace TechNovaLab.Irrigo.Application.Features.PlanterManagement.CreatePlanter
+{
+    public sealed record PlanterResponse(
+        Guid PublicId,
+        string Name,
+        string Description);
+}

--- a/src/TechNovaLab.Irrigo.Application/TechNovaLab.Irrigo.Application.csproj
+++ b/src/TechNovaLab.Irrigo.Application/TechNovaLab.Irrigo.Application.csproj
@@ -22,8 +22,4 @@
     <ProjectReference Include="..\TechNovaLab.Irrigo.Domain\TechNovaLab.Irrigo.Domain.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Features\PlanterManagement\" />
-  </ItemGroup>
-
 </Project>

--- a/src/TechNovaLab.Irrigo.Domain/Errors/PlanterErrors.cs
+++ b/src/TechNovaLab.Irrigo.Domain/Errors/PlanterErrors.cs
@@ -1,0 +1,10 @@
+﻿using TechNovaLab.Irrigo.SharedKernel.Errors;
+
+namespace TechNovaLab.Irrigo.Domain.Errors
+{
+    public static class PlanterErrors
+    {
+        public static readonly Error NameNotUnique = Error.Conflict(
+            "Planters.NameNotUnique", "The provided name is not unique.");
+    }
+}


### PR DESCRIPTION
- Se añadió el caso de uso CreatePlanter para gestionar la lógica de creación de jardineras.
- Se creó el endpoint correspondiente en el controlador para exponer la funcionalidad.
- Se actualizaron las dependencias del servicio para incluir el caso de uso.