### PR TITLE
feat: ✨ ajustar tipo de dato 'WaterRequiredPerDay' de `int` a `double`

### DIFF
--- a/src/TechNovaLab.Irrigo.Domain/Entities/Crops/Crop.cs
+++ b/src/TechNovaLab.Irrigo.Domain/Entities/Crops/Crop.cs
@@ -13,6 +13,7 @@ namespace TechNovaLab.Irrigo.Domain.Entities.Crops
         public int PlanterId { get; set; }
         public int SprinklerGroupId { get; set; }
         public required string Name { get; set; }
+
         /// <summary>
         /// Number of individual plants or units of this crop type planted in the planter.
         /// </summary>
@@ -29,7 +30,7 @@ namespace TechNovaLab.Irrigo.Domain.Entities.Crops
             {
                 if (CropType != null)
                 {
-                    return (double)CropType.WaterRequiredPerDay * PlantUnits;
+                    return CropType.WaterRequiredPerDay * PlantUnits;
                 }
 
                 return 0D;

--- a/src/TechNovaLab.Irrigo.Domain/Entities/Crops/CropType.cs
+++ b/src/TechNovaLab.Irrigo.Domain/Entities/Crops/CropType.cs
@@ -10,7 +10,7 @@ namespace TechNovaLab.Irrigo.Domain.Entities.Crops
         /// <summary>
         /// Amount of water required per day (in liters).
         /// </summary>
-        public int WaterRequiredPerDay { get; set; }
+        public double WaterRequiredPerDay { get; set; }
         public ICollection<Crop> Crops { get; set; } = [];
     }
 }


### PR DESCRIPTION
### Descripción
Se actualiza la propiedad `WaterRequiredPerDay` en la entidad `CropType` de `int` a `double`. Este cambio es necesario para permitir una definición más precisa en los datos de riego de los cultivos.

### Cambios realizados
- Modificación del tipo de dato de la propiedad `WaterRequiredPerDay` en `CropType`.

### Checklist
- [x] Código actualizado.
