### PR TITLE
feat(cors): 🎯 Configurar políticas por defecto para CORS en desarrollo local

### DIFF
--- a/src/TechNovaLab.Irrigo.Api/Configurations/DependencyInjection.cs
+++ b/src/TechNovaLab.Irrigo.Api/Configurations/DependencyInjection.cs
@@ -7,9 +7,10 @@ namespace TechNovaLab.Irrigo.Api.Configurations
 {
     public static class DependencyInjection
     {
-        public static IServiceCollection AddPresentation(this IServiceCollection services) =>
+        public static IServiceCollection AddPresentation(this IServiceCollection services, IConfiguration configuration) =>
             services
                 .AddExceptionHandler<GlobalExceptionHandler>()
+                .AddCorsRules(configuration)
                 .AddEndpointsApiExplorer()
                 .AddProblemDetails()
                 .AddEndpoints();
@@ -27,5 +28,11 @@ namespace TechNovaLab.Irrigo.Api.Configurations
 
             return services;
         }
+
+        private static IServiceCollection AddCorsRules(this IServiceCollection services, IConfiguration configuration) =>
+            services.AddCors(options => options
+                .AddDefaultPolicy(builder => builder.WithOrigins(configuration.GetSection("Cors:Origins").Get<string[]>() ?? [])
+                .AllowAnyHeader()
+                .AllowAnyMethod()));
     }
 }

--- a/src/TechNovaLab.Irrigo.Api/Program.cs
+++ b/src/TechNovaLab.Irrigo.Api/Program.cs
@@ -14,7 +14,7 @@ builder.Host
 builder.Services
     .AddSwaggerGenWithAuth(builder.Configuration)
     .AddApplication()
-    .AddPresentation()
+    .AddPresentation(builder.Configuration)
     .AddInfrastructure(builder.Configuration);
 
 WebApplication app = builder.Build();
@@ -37,5 +37,6 @@ app.UseSerilogRequestLogging();
 app.UseExceptionHandler();
 app.UseAuthentication();
 app.UseAuthorization();
+app.UseCors();
 
 await app.RunAsync();

--- a/src/TechNovaLab.Irrigo.Api/appsettings.Development.json
+++ b/src/TechNovaLab.Irrigo.Api/appsettings.Development.json
@@ -9,6 +9,12 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "Cors": {
+    "Origins": [
+      "http://localhost:3000",
+      "http://localhost:3001"
+    ]
+  },
   "ConnectionStrings": {
     "Database": "Host=postgres;Port=5432;Database=irrigo-db;Username=postgres;Password=postgres;Include Error Detail=true"
   },


### PR DESCRIPTION
#### Descripción
Se añaden políticas por defecto en CORS para soportar el desarrollo local de manera adecuada, permitiendo:
- Orígenes locales específicos (`http://localhost:3000` y `http://localhost:3001`).
- Métodos comunes para peticiones RESTful (`GET`, `POST`, `PUT`, `DELETE`).
- Soporte para peticiones preflight (método `OPTIONS`).

#### Cambios realizados
1. Configuración inicial de `CorsPolicyBuilder` para desarrollo local.

#### Impacto
✔ Mejora el soporte de pruebas locales sin comprometer seguridad en producción.
✔ Facilita el desarrollo en equipo con herramientas como React, Angular o cualquier frontend local.

---
