### PR TITLE
feat: 🌱 Añadir propiedad Name a SprinklerGroup

### DIFF
--- a/src/TechNovaLab.Irrigo.Api/Endpoints/Sprinklers/CreateSprinklerGroup.cs
+++ b/src/TechNovaLab.Irrigo.Api/Endpoints/Sprinklers/CreateSprinklerGroup.cs
@@ -7,13 +7,15 @@ using TechNovaLab.Irrigo.SharedKernel.Core;
 
 namespace TechNovaLab.Irrigo.Api.Endpoints.Sprinklers
 {
+    public sealed record Request(string Name);
+
     internal sealed class CreateSprinklerGroup : IEndpoint
     {
         public void MapEndpoint(IEndpointRouteBuilder app)
         {
-            app.MapPost("sprinklers/create-group", async (ISender sender, CancellationToken cancellationToken) =>
+            app.MapPost("sprinklers/create-group", async (Request request, ISender sender, CancellationToken cancellationToken) =>
             {
-                var command = new CreateSprinklerGroupCommand();
+                var command = new CreateSprinklerGroupCommand(request.Name);
                 Result<SprinklerGroupResponse> result = await sender.Send(command, cancellationToken);
 
                 return result.Match(Results.Ok, CustomResults.Problem);

--- a/src/TechNovaLab.Irrigo.Application/Features/SprinklerManagement/CreateSprinklerGroup/CreateSprinklerGroupCommand.cs
+++ b/src/TechNovaLab.Irrigo.Application/Features/SprinklerManagement/CreateSprinklerGroup/CreateSprinklerGroupCommand.cs
@@ -2,5 +2,5 @@
 
 namespace TechNovaLab.Irrigo.Application.Features.SprinklerManagement.CreateSprinklerGroup
 {
-    public sealed record CreateSprinklerGroupCommand : ICommand<SprinklerGroupResponse>;
+    public sealed record CreateSprinklerGroupCommand(string Name) : ICommand<SprinklerGroupResponse>;
 }

--- a/src/TechNovaLab.Irrigo.Application/Features/SprinklerManagement/CreateSprinklerGroup/CreateSprinklerGroupCommandHandler.cs
+++ b/src/TechNovaLab.Irrigo.Application/Features/SprinklerManagement/CreateSprinklerGroup/CreateSprinklerGroupCommandHandler.cs
@@ -15,6 +15,7 @@ namespace TechNovaLab.Irrigo.Application.Features.SprinklerManagement.CreateSpri
             var group = new SprinklerGroup
             {
                 PublicId = Guid.NewGuid(),
+                Name = command.Name,
                 State = State.Inactive,
             };
 
@@ -23,6 +24,7 @@ namespace TechNovaLab.Irrigo.Application.Features.SprinklerManagement.CreateSpri
 
             return new SprinklerGroupResponse(
                 group.PublicId,
+                group.Name,
                 group.State,
                 group.WaterConsumptionPerSession,
                 group.ActiveMinutesPerSession);

--- a/src/TechNovaLab.Irrigo.Application/Features/SprinklerManagement/CreateSprinklerGroup/SprinklerGroupResponse.cs
+++ b/src/TechNovaLab.Irrigo.Application/Features/SprinklerManagement/CreateSprinklerGroup/SprinklerGroupResponse.cs
@@ -4,6 +4,7 @@ namespace TechNovaLab.Irrigo.Application.Features.SprinklerManagement.CreateSpri
 {
     public sealed record SprinklerGroupResponse(
         Guid PublicId,
+        string Name,
         State State,
         double WaterConsumptionPerSession,
         double ActiveMinutesPerSession);

--- a/src/TechNovaLab.Irrigo.Domain/Entities/Sprinklers/SprinklerGroup.cs
+++ b/src/TechNovaLab.Irrigo.Domain/Entities/Sprinklers/SprinklerGroup.cs
@@ -10,6 +10,7 @@ namespace TechNovaLab.Irrigo.Domain.Entities.Sprinklers
     {
         public int Id { get; set; }
         public Guid PublicId { get; set; }
+        public required string Name { get; set; }
         public State State { get; set; }
 
         [NotMapped]

--- a/src/TechNovaLab.Irrigo.Infrastructure/Database/Configurations/Sprinklers/SprinklerEntitiesConfigurator.cs
+++ b/src/TechNovaLab.Irrigo.Infrastructure/Database/Configurations/Sprinklers/SprinklerEntitiesConfigurator.cs
@@ -7,7 +7,7 @@ namespace TechNovaLab.Irrigo.Infrastructure.Database.Configurations.Sprinklers
         internal static void ApplySprinklersModelConfiguration(this ModelBuilder modelBuilder)
         {
             new SprinklerEntityConfiguration().Configure(modelBuilder);
-            new SprinklerGroupEntityConfigurator().Configure(modelBuilder);
+            new SprinklerGroupEntityConfiguration().Configure(modelBuilder);
         }
     }
 }

--- a/src/TechNovaLab.Irrigo.Infrastructure/Database/Configurations/Sprinklers/SprinklerGroupEntityConfiguration.cs
+++ b/src/TechNovaLab.Irrigo.Infrastructure/Database/Configurations/Sprinklers/SprinklerGroupEntityConfiguration.cs
@@ -4,7 +4,7 @@ using TechNovaLab.Irrigo.Infrastructure.Database.Abstractions;
 
 namespace TechNovaLab.Irrigo.Infrastructure.Database.Configurations.Sprinklers
 {
-    internal class SprinklerGroupEntityConfigurator : EntityConfiguratorBase<SprinklerGroup>
+    internal class SprinklerGroupEntityConfiguration : EntityConfiguratorBase<SprinklerGroup>
     {
         public override void Configure(ModelBuilder modelBuilder)
         {


### PR DESCRIPTION
### Cambios realizados:
- Modificada la entidad `SprinklerGroup` para incluir la propiedad `Name`.
- Actualización del caso de uso `CreateSprinklerGroup` para manejar el nuevo parámetro.
- Modificación del endpoint `create-sprinkler-group` para recibir la propiedad `Name`.
- Renombrado del archivo `SprinklerGroupEntityConfigurator` para mantener coherencia en los sufijos.

### Razón del cambio:
Se necesita que los grupos de aspersores tengan una propiedad `Name` para identificarlos de manera más clara, cumpliendo con los requisitos funcionales del sistema.

### Pruebas realizadas:
- Verificado que la entidad `SprinklerGroup` acepte la propiedad `Name`.
- Probado el endpoint con datos de ejemplo para asegurar la correcta funcionalidad.
- Confirmado que el renombrado del archivo no afecta las configuraciones existentes."
