### PR TITLE
feat: :shield: agregar middleware para manejar errores 401 y 403

### DIFF
--- a/src/TechNovaLab.Irrigo.Api/Configurations/DependencyInjection.cs
+++ b/src/TechNovaLab.Irrigo.Api/Configurations/DependencyInjection.cs
@@ -33,6 +33,17 @@ namespace TechNovaLab.Irrigo.Api.Configurations
             services.AddCors(options => options
                 .AddDefaultPolicy(builder => builder.WithOrigins(configuration.GetSection("Cors:Origins").Get<string[]>() ?? [])
                 .AllowAnyHeader()
-                .AllowAnyMethod()));
+                .AllowAnyMethod()
+                .AllowCredentials()
+                .WithExposedHeaders("Access-Control-Allow-Origin")));
+
+        //services.AddCors(options => options
+        //   .AddDefaultPolicy(builder => builder.WithOrigins(configuration.GetSection("Cors:Origins").Get<string[]>() ?? [])
+        //   .AllowAnyHeader()
+        //   .AllowAnyMethod()
+        //   .AllowCredentials()
+        //   .WithExposedHeaders("WWW-Authenticate", "Access-Control-Allow-Origin", "Content-type", "Authorization")
+        //   .SetPreflightMaxAge(TimeSpan.FromMinutes(10))));
+
     }
 }

--- a/src/TechNovaLab.Irrigo.Api/Extensions/MiddlewareExtensions.cs
+++ b/src/TechNovaLab.Irrigo.Api/Extensions/MiddlewareExtensions.cs
@@ -4,11 +4,10 @@ namespace TechNovaLab.Irrigo.Api.Extensions
 {
     public static class MiddlewareExtensions
     {
-        public static IApplicationBuilder UseRequestContextLogging(this IApplicationBuilder app)
-        {
+        public static IApplicationBuilder UseRequestContextLogging(this IApplicationBuilder app) =>       
             app.UseMiddleware<RequestContextLoggingMiddleware>();
 
-            return app;
-        }
+        public static IApplicationBuilder UseRequestAuthorizationMiddleware(this IApplicationBuilder app) =>
+            app.UseMiddleware<RequestAuthorizationMiddleware>();
     }
 }

--- a/src/TechNovaLab.Irrigo.Api/Infrastructure/CustomResults.cs
+++ b/src/TechNovaLab.Irrigo.Api/Infrastructure/CustomResults.cs
@@ -26,6 +26,8 @@ namespace TechNovaLab.Irrigo.Api.Infrastructure
                     ErrorType.Problem => error.Code,
                     ErrorType.NotFound => error.Code,
                     ErrorType.Conflict => error.Code,
+                    ErrorType.Unauthorized => error.Code,
+                    ErrorType.Forbidden => error.Code,
                     _ => "Server failure"
                 };
 
@@ -36,6 +38,8 @@ namespace TechNovaLab.Irrigo.Api.Infrastructure
                     ErrorType.Problem => error.Description,
                     ErrorType.NotFound => error.Description,
                     ErrorType.Conflict => error.Description,
+                    ErrorType.Unauthorized => error.Description,
+                    ErrorType.Forbidden => error.Description,
                     _ => "An unexpected error occurred"
                 };
 
@@ -46,6 +50,8 @@ namespace TechNovaLab.Irrigo.Api.Infrastructure
                     ErrorType.Problem => "https://tools.ietf.org/html/rfc7231#section-6.5.1",
                     ErrorType.NotFound => "https://tools.ietf.org/html/rfc7231#section-6.5.4",
                     ErrorType.Conflict => "https://tools.ietf.org/html/rfc7231#section-6.5.8",
+                    ErrorType.Unauthorized => "https://tools.ietf.org/html/rfc7231#section-3.1",
+                    ErrorType.Forbidden => "https://tools.ietf.org/html/rfc7231#section-6.5.3",
                     _ => "https://tools.ietf.org/html/rfc7231#section-6.6.1"
                 };
 
@@ -53,6 +59,8 @@ namespace TechNovaLab.Irrigo.Api.Infrastructure
                 errorType switch
                 {
                     ErrorType.Validation => StatusCodes.Status400BadRequest,
+                    ErrorType.Unauthorized => StatusCodes.Status401Unauthorized,
+                    ErrorType.Forbidden => StatusCodes.Status403Forbidden,
                     ErrorType.NotFound => StatusCodes.Status404NotFound,
                     ErrorType.Conflict => StatusCodes.Status409Conflict,
                     _ => StatusCodes.Status500InternalServerError

--- a/src/TechNovaLab.Irrigo.Api/Middleware/RequestAuthorizationMiddleware.cs
+++ b/src/TechNovaLab.Irrigo.Api/Middleware/RequestAuthorizationMiddleware.cs
@@ -1,0 +1,44 @@
+﻿using TechNovaLab.Irrigo.Api.Infrastructure;
+using TechNovaLab.Irrigo.SharedKernel.Core;
+using TechNovaLab.Irrigo.SharedKernel.Errors;
+
+namespace TechNovaLab.Irrigo.Api.Middleware
+{
+    public class RequestAuthorizationMiddleware(RequestDelegate next)
+    {
+        public async Task Invoke(HttpContext context)
+        {
+            await next(context);
+
+            if (context.Response.StatusCode == StatusCodes.Status401Unauthorized ||
+                context.Response.StatusCode == StatusCodes.Status403Forbidden)
+            {
+                context.Response.ContentType = "application/json";
+                context.Response.Headers.Append("Access-Control-Allow-Origin", context.Request.Headers.Origin);
+
+                var result = context.Response.StatusCode switch
+                {
+                    StatusCodes.Status401Unauthorized => Result.Failure(
+                        new Error(
+                            "Unauthorized",
+                            "The token is either missing or has expired. Please log in again.",
+                            ErrorType.Unauthorized)),
+
+                    StatusCodes.Status403Forbidden => Result.Failure(
+                        new Error(
+                            "Forbidden",
+                            "You do not have the required role or permissions to perform this action.",
+                            ErrorType.Forbidden)),
+
+                    _ => Result.Failure(
+                        new Error(
+                            "Unknown",
+                            "An unknown authorization error occurred.",
+                            ErrorType.Problem))
+                };
+
+                await CustomResults.Problem(result).ExecuteAsync(context);
+            }
+        }
+    }
+}

--- a/src/TechNovaLab.Irrigo.Api/Program.cs
+++ b/src/TechNovaLab.Irrigo.Api/Program.cs
@@ -33,6 +33,7 @@ app.MapHealthChecks("health", new HealthCheckOptions
 });
 
 app.UseRequestContextLogging();
+app.UseRequestAuthorizationMiddleware();
 app.UseSerilogRequestLogging();
 app.UseExceptionHandler();
 app.UseAuthentication();

--- a/src/TechNovaLab.Irrigo.SharedKernel/Errors/ErrorType.cs
+++ b/src/TechNovaLab.Irrigo.SharedKernel/Errors/ErrorType.cs
@@ -6,6 +6,8 @@
         Validation = 1,
         Problem = 2,
         NotFound = 3,
-        Conflict = 4
+        Conflict = 4,
+        Unauthorized = 5,
+        Forbidden = 6
     }
 }


### PR DESCRIPTION
### Descripción
Se implementa un middleware para interceptar y manejar de forma estándar los errores 401 (Unauthorized) y 403 (Forbidden) en la API. Este cambio asegura una comunicación consistente con el frontend.

### Cambios realizados
- Implementación de un middleware en la API para interceptar errores 401 y 403.
- Creación de nuevos tipos de error para estandarizar las respuestas.
- Mejora de la experiencia del frontend al recibir errores bien definidos.

### Impacto
Este cambio mejora la seguridad y la consistencia en la comunicación entre el backend y el frontend.
