### PR TITLE
feat(endpoint): 🌱 Crear endpoint y query GetCropTypes

### DIFF
--- a/src/TechNovaLab.Irrigo.Api/Endpoints/Crops/CreateCrop.cs
+++ b/src/TechNovaLab.Irrigo.Api/Endpoints/Crops/CreateCrop.cs
@@ -2,6 +2,7 @@
 using TechNovaLab.Irrigo.Api.Extensions;
 using TechNovaLab.Irrigo.Api.Infrastructure;
 using TechNovaLab.Irrigo.Application.Features.CropManagement.CreateCrop;
+using TechNovaLab.Irrigo.Domain.Entities.Users;
 using TechNovaLab.Irrigo.SharedKernel.Core;
 
 namespace TechNovaLab.Irrigo.Api.Endpoints.Crops
@@ -29,7 +30,10 @@ namespace TechNovaLab.Irrigo.Api.Endpoints.Crops
                 Result<CropResponse> result = await sender.Send(command, cancellationToken);
 
                 return result.Match(Results.Ok, CustomResults.Problem);
-            });
+            })
+            .HasRole(Role.Member)
+            .HasPermission("user:access")
+            .WithTags(Tags.Crops);
         }
     }
 }

--- a/src/TechNovaLab.Irrigo.Api/Endpoints/Crops/CreateCropType.cs
+++ b/src/TechNovaLab.Irrigo.Api/Endpoints/Crops/CreateCropType.cs
@@ -2,6 +2,7 @@
 using TechNovaLab.Irrigo.Api.Extensions;
 using TechNovaLab.Irrigo.Api.Infrastructure;
 using TechNovaLab.Irrigo.Application.Features.CropManagement.CreateCropType;
+using TechNovaLab.Irrigo.Domain.Entities.Users;
 using TechNovaLab.Irrigo.SharedKernel.Core;
 
 namespace TechNovaLab.Irrigo.Api.Endpoints.Crops
@@ -21,7 +22,10 @@ namespace TechNovaLab.Irrigo.Api.Endpoints.Crops
                 Result<CropTypeResponse> result = await sender.Send(command, cancellationToken);
 
                 return result.Match(Results.Ok, CustomResults.Problem);
-            });
+            })
+            .HasRole(Role.Member)
+            .HasPermission("user:access")
+            .WithTags(Tags.Crops);
         }
     }
 }

--- a/src/TechNovaLab.Irrigo.Api/Endpoints/Crops/GetCropTypes.cs
+++ b/src/TechNovaLab.Irrigo.Api/Endpoints/Crops/GetCropTypes.cs
@@ -1,0 +1,27 @@
+﻿using MediatR;
+using TechNovaLab.Irrigo.Api.Extensions;
+using TechNovaLab.Irrigo.Api.Infrastructure;
+using TechNovaLab.Irrigo.Application.Features.CropManagement.GetCropTypes;
+using TechNovaLab.Irrigo.Domain.Entities.Users;
+using TechNovaLab.Irrigo.SharedKernel.Core;
+
+namespace TechNovaLab.Irrigo.Api.Endpoints.Crops
+{
+    internal sealed class GetCropTypes : IEndpoint
+    {
+        public void MapEndpoint(IEndpointRouteBuilder app)
+        {
+            app.MapGet("crops", async (ISender sender, CancellationToken cancaellationToken) =>
+            {
+                var query = new GetCropTypesQuery();
+
+                Result<IEnumerable<CropTypesResponse>> result = await sender.Send(query, cancaellationToken);
+
+                return result.Match(Results.Ok, CustomResults.Problem);
+            })
+            .HasRole(Role.Guest)
+            .HasPermission("users:access")
+            .WithTags(Tags.Crops);
+        }
+    }
+}

--- a/src/TechNovaLab.Irrigo.Api/Endpoints/Tags.cs
+++ b/src/TechNovaLab.Irrigo.Api/Endpoints/Tags.cs
@@ -5,5 +5,6 @@
         public const string HealthChecks = "HealthChecks";
         public const string Sprinklers = "Sprinklers";
         public const string Users = "Users";
+        public const string Crops = "Crops";
     }
 }

--- a/src/TechNovaLab.Irrigo.Application/Features/CropManagement/GetCropTypes/CropTypesResponse.cs
+++ b/src/TechNovaLab.Irrigo.Application/Features/CropManagement/GetCropTypes/CropTypesResponse.cs
@@ -1,0 +1,10 @@
+﻿namespace TechNovaLab.Irrigo.Application.Features.CropManagement.GetCropTypes
+{
+    public sealed record CropTypesResponse
+    {
+        public Guid PublicId { get; init; }
+        public string Name { get; init; } = default!;
+        public double WaterRequiredPerDay { get; init; }
+    }
+
+}

--- a/src/TechNovaLab.Irrigo.Application/Features/CropManagement/GetCropTypes/GetCropTypesQuery.cs
+++ b/src/TechNovaLab.Irrigo.Application/Features/CropManagement/GetCropTypes/GetCropTypesQuery.cs
@@ -1,0 +1,7 @@
+﻿using TechNovaLab.Irrigo.Application.Abstractions.Messaging;
+
+namespace TechNovaLab.Irrigo.Application.Features.CropManagement.GetCropTypes
+{
+    public sealed record GetCropTypesQuery: IQuery<IEnumerable<CropTypesResponse>>;
+
+}

--- a/src/TechNovaLab.Irrigo.Application/Features/CropManagement/GetCropTypes/GetCropTypesQueryHandler.cs
+++ b/src/TechNovaLab.Irrigo.Application/Features/CropManagement/GetCropTypes/GetCropTypesQueryHandler.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.EntityFrameworkCore;
+using TechNovaLab.Irrigo.Application.Abstractions.Messaging;
+using TechNovaLab.Irrigo.Domain.Entities.Crops;
+using TechNovaLab.Irrigo.Domain.Repositories;
+using TechNovaLab.Irrigo.SharedKernel.Core;
+
+namespace TechNovaLab.Irrigo.Application.Features.CropManagement.GetCropTypes
+{
+    internal sealed class GetCropTypesQueryHandler(
+        IRepository repository) : IQueryHandler<GetCropTypesQuery, IEnumerable<CropTypesResponse>>
+    {
+        public async Task<Result<IEnumerable<CropTypesResponse>>> Handle(GetCropTypesQuery request, CancellationToken cancellationToken)
+        {
+            List<CropTypesResponse> cropTypes = await repository
+                .Get<CropType>()
+                .Select(x => new CropTypesResponse
+                {
+                    PublicId = x.PublicId,
+                    Name = x.Name,
+                    WaterRequiredPerDay = x.WaterRequiredPerDay,
+                }).ToListAsync(cancellationToken);
+
+            return cropTypes;
+        }
+    }
+
+}

--- a/src/TechNovaLab.Irrigo.Infrastructure/Configurations/DependencyInjection.cs
+++ b/src/TechNovaLab.Irrigo.Infrastructure/Configurations/DependencyInjection.cs
@@ -69,6 +69,7 @@ namespace TechNovaLab.Irrigo.Infrastructure.Configurations
                     option.RequireHttpsMetadata = false;
                     option.TokenValidationParameters = new TokenValidationParameters
                     {
+                        ValidateLifetime = true,
                         IssuerSigningKey = signingKey,
                         ValidIssuer = configuration["Jwt:Issuer"],
                         ValidAudience = configuration["Jwt:Audience"],


### PR DESCRIPTION
### Descripción
Se ha añadido el endpoint `GetCropTypes` junto con la query correspondiente para obtener la lista de tipos de cultivos disponibles. Este cambio incluye:
- Implementación del endpoint en la capa de control.
- Query en la capa de datos para recuperar los tipos de cultivo.

### Cambios realizados
1. Creación del endpoint `GetCropTypes`.
2. Implementación de la query en la capa de datos.

### Notas adicionales
- Revisar posibles escenarios de paginación y filtros si son necesarios.
- Se podría considerar agregar pruebas unitarias para la capa de datos y de integración para el endpoint.
