### PR TITLE
feat(api): 🌱 creación del endpoint y query para listar grupos de aspersores

### DIFF
--- a/src/TechNovaLab.Irrigo.Api/Endpoints/Sprinklers/GetSprinklerGroups.cs
+++ b/src/TechNovaLab.Irrigo.Api/Endpoints/Sprinklers/GetSprinklerGroups.cs
@@ -1,0 +1,27 @@
+﻿using MediatR;
+using TechNovaLab.Irrigo.Api.Extensions;
+using TechNovaLab.Irrigo.Api.Infrastructure;
+using TechNovaLab.Irrigo.Application.Features.SprinklerManagement.GetSprinklerGroups;
+using TechNovaLab.Irrigo.Domain.Entities.Users;
+using TechNovaLab.Irrigo.SharedKernel.Core;
+
+namespace TechNovaLab.Irrigo.Api.Endpoints.Sprinklers
+{
+    internal sealed class GetSprinklerGroups : IEndpoint
+    {
+        public void MapEndpoint(IEndpointRouteBuilder app)
+        {
+            app.MapGet("sprinklers/sprinkler-groups", async (ISender sender, CancellationToken cancellationToken) =>
+            {
+                var query = new GetSprinklerGroupsQuery();
+
+                Result<IEnumerable<SprinklerGroupResponse>> result = await sender.Send(query, cancellationToken);
+
+                return result.Match(Results.Ok, CustomResults.Problem);
+            })
+            .HasRole(Role.Guest)
+            .HasPermission("users:access")
+            .WithTags(Tags.Sprinklers);
+        }
+    }
+}

--- a/src/TechNovaLab.Irrigo.Application/Features/SprinklerManagement/GetSprinklerGroups/GetSprinklerGroupsQuery.cs
+++ b/src/TechNovaLab.Irrigo.Application/Features/SprinklerManagement/GetSprinklerGroups/GetSprinklerGroupsQuery.cs
@@ -1,0 +1,6 @@
+﻿using TechNovaLab.Irrigo.Application.Abstractions.Messaging;
+
+namespace TechNovaLab.Irrigo.Application.Features.SprinklerManagement.GetSprinklerGroups
+{
+    public sealed record GetSprinklerGroupsQuery : IQuery<IEnumerable<SprinklerGroupResponse>>;
+}

--- a/src/TechNovaLab.Irrigo.Application/Features/SprinklerManagement/GetSprinklerGroups/GetSprinklerGroupsQueryHandler.cs
+++ b/src/TechNovaLab.Irrigo.Application/Features/SprinklerManagement/GetSprinklerGroups/GetSprinklerGroupsQueryHandler.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore;
+using TechNovaLab.Irrigo.Application.Abstractions.Messaging;
+using TechNovaLab.Irrigo.Domain.Entities.Sprinklers;
+using TechNovaLab.Irrigo.Domain.Repositories;
+using TechNovaLab.Irrigo.SharedKernel.Core;
+
+namespace TechNovaLab.Irrigo.Application.Features.SprinklerManagement.GetSprinklerGroups
+{
+    internal sealed class GetSprinklerGroupsQueryHandler(
+        IRepository repository) : IQueryHandler<GetSprinklerGroupsQuery, IEnumerable<SprinklerGroupResponse>>
+    {
+        public async Task<Result<IEnumerable<SprinklerGroupResponse>>> Handle(GetSprinklerGroupsQuery request, CancellationToken cancellationToken)
+        {
+            List<SprinklerGroupResponse> sprinklerGroups = await repository
+                .Get<SprinklerGroup>()
+                .Select(x => new SprinklerGroupResponse
+                {
+                    PublicId = x.PublicId,
+                    Name = x.Name,
+                    State = x.State,
+                    WaterConsumptionPerSession = x.WaterConsumptionPerSession,
+                    ActiveMinutesPerSession = x.ActiveMinutesPerSession,
+                }).ToListAsync(cancellationToken);
+
+            return sprinklerGroups;
+        }
+    }
+}

--- a/src/TechNovaLab.Irrigo.Application/Features/SprinklerManagement/GetSprinklerGroups/SprinklerGroupResponse.cs
+++ b/src/TechNovaLab.Irrigo.Application/Features/SprinklerManagement/GetSprinklerGroups/SprinklerGroupResponse.cs
@@ -1,0 +1,13 @@
+﻿using TechNovaLab.Irrigo.Domain.Entities.Sprinklers;
+
+namespace TechNovaLab.Irrigo.Application.Features.SprinklerManagement.GetSprinklerGroups
+{
+    public sealed record SprinklerGroupResponse
+    {
+        public Guid PublicId { get; init; }
+        public string Name { get; init; } = default!;
+        public State State { get; init; }
+        public double WaterConsumptionPerSession { get; init; }
+        public double ActiveMinutesPerSession { get; init; }
+    }
+}


### PR DESCRIPTION
**Descripción del cambio:**
Se añade un nuevo endpoint para obtener el listado de grupos de aspersores, con los siguientes componentes:

- Endpoint: `GetSprinklerGroups`.
- Query y handler para gestionar la lógica de obtención.
- Modelo de respuesta: `SprinklerGroupResponse`.

**Motivación:**
Esta funcionalidad permite recuperar datos organizados para la gestión de grupos de aspersores en el sistema.

**Impacto:**
- Agregado un nuevo endpoint.
- Extendido el módulo de gestión de aspersores.