### PR TITLE
feat(create-crop): ✨ mejorar creación de cultivos con IDs en respuestas

### DIFF
--- a/src/TechNovaLab.Irrigo.Api/Endpoints/Crops/CreateCrop.cs
+++ b/src/TechNovaLab.Irrigo.Api/Endpoints/Crops/CreateCrop.cs
@@ -32,7 +32,7 @@ namespace TechNovaLab.Irrigo.Api.Endpoints.Crops
                 return result.Match(Results.Ok, CustomResults.Problem);
             })
             .HasRole(Role.Member)
-            .HasPermission("user:access")
+            .HasPermission("users:access")
             .WithTags(Tags.Crops);
         }
     }

--- a/src/TechNovaLab.Irrigo.Application/Features/CropManagement/CreateCrop/CreateCropCommandHandler.cs
+++ b/src/TechNovaLab.Irrigo.Application/Features/CropManagement/CreateCrop/CreateCropCommandHandler.cs
@@ -44,6 +44,7 @@ namespace TechNovaLab.Irrigo.Application.Features.CropManagement.CreateCrop
             await unitOfWork.CompleteAsync(cancellationToken);
 
             return new CropResponse(
+                crop.Id,
                 crop.PublicId,
                 crop.Name,
                 crop.PlantUnits,

--- a/src/TechNovaLab.Irrigo.Application/Features/CropManagement/CreateCrop/CropResponse.cs
+++ b/src/TechNovaLab.Irrigo.Application/Features/CropManagement/CreateCrop/CropResponse.cs
@@ -1,6 +1,7 @@
 ﻿namespace TechNovaLab.Irrigo.Application.Features.CropManagement.CreateCrop
 {
     public sealed record CropResponse(
+        int Id,
         Guid PublicId,
         string Name,
         int PlantUnits,

--- a/src/TechNovaLab.Irrigo.Application/Features/CropManagement/CreateCropType/CreateCropTypeCommandHandler.cs
+++ b/src/TechNovaLab.Irrigo.Application/Features/CropManagement/CreateCropType/CreateCropTypeCommandHandler.cs
@@ -34,6 +34,7 @@ namespace TechNovaLab.Irrigo.Application.Features.CropManagement.CreateCropType
             await unitOfWork.CompleteAsync(cancellationToken);
 
             return new CropTypeResponse(
+                cropType.Id,
                 cropType.PublicId,
                 cropType.Name,
                 cropType.WaterRequiredPerDay);

--- a/src/TechNovaLab.Irrigo.Application/Features/CropManagement/CreateCropType/CropTypeResponse.cs
+++ b/src/TechNovaLab.Irrigo.Application/Features/CropManagement/CreateCropType/CropTypeResponse.cs
@@ -1,6 +1,7 @@
 ﻿namespace TechNovaLab.Irrigo.Application.Features.CropManagement.CreateCropType
 {
     public sealed record CropTypeResponse(
+        int Id,
         Guid PublicId,
         string Name,
         double WaterRequiredPerDay);

--- a/src/TechNovaLab.Irrigo.Application/Features/CropManagement/GetCropTypes/CropTypeResponse.cs
+++ b/src/TechNovaLab.Irrigo.Application/Features/CropManagement/GetCropTypes/CropTypeResponse.cs
@@ -2,6 +2,7 @@
 {
     public sealed record CropTypeResponse
     {
+        public int Id { get; init; }
         public Guid PublicId { get; init; }
         public string Name { get; init; } = default!;
         public double WaterRequiredPerDay { get; init; }

--- a/src/TechNovaLab.Irrigo.Application/Features/CropManagement/GetCropTypes/GetCropTypesQueryHandler.cs
+++ b/src/TechNovaLab.Irrigo.Application/Features/CropManagement/GetCropTypes/GetCropTypesQueryHandler.cs
@@ -15,6 +15,7 @@ namespace TechNovaLab.Irrigo.Application.Features.CropManagement.GetCropTypes
                 .Get<CropType>()
                 .Select(x => new CropTypeResponse
                 {
+                    Id = x.Id,
                     PublicId = x.PublicId,
                     Name = x.Name,
                     WaterRequiredPerDay = x.WaterRequiredPerDay,

--- a/src/TechNovaLab.Irrigo.Application/Features/PlanterManagement/CreatePlanter/CreatePlanterCommandHandler.cs
+++ b/src/TechNovaLab.Irrigo.Application/Features/PlanterManagement/CreatePlanter/CreatePlanterCommandHandler.cs
@@ -34,6 +34,7 @@ namespace TechNovaLab.Irrigo.Application.Features.PlanterManagement.CreatePlante
             await unitOfWork.CompleteAsync(cancellationToken);
 
             return new PlanterResponse(
+                planter.Id,
                 planter.PublicId,
                 planter.Name,
                 planter.Description);

--- a/src/TechNovaLab.Irrigo.Application/Features/PlanterManagement/CreatePlanter/PlanterResponse.cs
+++ b/src/TechNovaLab.Irrigo.Application/Features/PlanterManagement/CreatePlanter/PlanterResponse.cs
@@ -1,6 +1,7 @@
 ﻿namespace TechNovaLab.Irrigo.Application.Features.PlanterManagement.CreatePlanter
 {
     public sealed record PlanterResponse(
+        int Id,
         Guid PublicId,
         string Name,
         string Description);

--- a/src/TechNovaLab.Irrigo.Application/Features/PlanterManagement/GetPlanters/GetPlantersQueryHandler.cs
+++ b/src/TechNovaLab.Irrigo.Application/Features/PlanterManagement/GetPlanters/GetPlantersQueryHandler.cs
@@ -15,6 +15,7 @@ namespace TechNovaLab.Irrigo.Application.Features.PlanterManagement.GetPlanters
                 .Get<Planter>()
                 .Select(x => new PlanterResponse
                 {
+                    Id = x.Id,
                     PublicId = x.PublicId,
                     Name = x.Name,
                     Description = x.Description,

--- a/src/TechNovaLab.Irrigo.Application/Features/PlanterManagement/GetPlanters/PlanterResponse.cs
+++ b/src/TechNovaLab.Irrigo.Application/Features/PlanterManagement/GetPlanters/PlanterResponse.cs
@@ -2,6 +2,7 @@
 {
     public sealed record PlanterResponse
     {
+        public int Id { get; init; }
         public Guid PublicId { get; init; }
         public string Name { get; init; } = default!;
         public string Description { get; init; } = default!;

--- a/src/TechNovaLab.Irrigo.Application/Features/SprinklerManagement/CreateSprinklerGroup/CreateSprinklerGroupCommandHandler.cs
+++ b/src/TechNovaLab.Irrigo.Application/Features/SprinklerManagement/CreateSprinklerGroup/CreateSprinklerGroupCommandHandler.cs
@@ -23,6 +23,7 @@ namespace TechNovaLab.Irrigo.Application.Features.SprinklerManagement.CreateSpri
             await unitOfWork.CompleteAsync(cancellationToken);
 
             return new SprinklerGroupResponse(
+                group.Id,
                 group.PublicId,
                 group.Name,
                 group.State,

--- a/src/TechNovaLab.Irrigo.Application/Features/SprinklerManagement/CreateSprinklerGroup/SprinklerGroupResponse.cs
+++ b/src/TechNovaLab.Irrigo.Application/Features/SprinklerManagement/CreateSprinklerGroup/SprinklerGroupResponse.cs
@@ -3,6 +3,7 @@
 namespace TechNovaLab.Irrigo.Application.Features.SprinklerManagement.CreateSprinklerGroup
 {
     public sealed record SprinklerGroupResponse(
+        int Id,
         Guid PublicId,
         string Name,
         State State,

--- a/src/TechNovaLab.Irrigo.Application/Features/SprinklerManagement/GetSprinklerGroups/GetSprinklerGroupsQueryHandler.cs
+++ b/src/TechNovaLab.Irrigo.Application/Features/SprinklerManagement/GetSprinklerGroups/GetSprinklerGroupsQueryHandler.cs
@@ -15,6 +15,7 @@ namespace TechNovaLab.Irrigo.Application.Features.SprinklerManagement.GetSprinkl
                 .Get<SprinklerGroup>()
                 .Select(x => new SprinklerGroupResponse
                 {
+                    Id = x.Id,
                     PublicId = x.PublicId,
                     Name = x.Name,
                     State = x.State,

--- a/src/TechNovaLab.Irrigo.Application/Features/SprinklerManagement/GetSprinklerGroups/SprinklerGroupResponse.cs
+++ b/src/TechNovaLab.Irrigo.Application/Features/SprinklerManagement/GetSprinklerGroups/SprinklerGroupResponse.cs
@@ -4,6 +4,7 @@ namespace TechNovaLab.Irrigo.Application.Features.SprinklerManagement.GetSprinkl
 {
     public sealed record SprinklerGroupResponse
     {
+        public int Id { get; init; }
         public Guid PublicId { get; init; }
         public string Name { get; init; } = default!;
         public State State { get; init; }


### PR DESCRIPTION
### Descripción
Se implementa una mejora significativa en la funcionalidad de creación de cultivos. Los comandos y queries ahora devuelven los IDs en las respuestas, facilitando el flujo de datos entre las capas de la aplicación.

### Cambios principales
- Actualización del handler de creación de cultivos para incluir IDs en las respuestas.
- Refactorización de las respuestas de `CropType`, `Planter`, y `SprinklerGroup`.
- Ajustes en los queries para garantizar datos consistentes con la nueva estructura.

### Impacto
- Mejora en la experiencia del desarrollador al manejar datos.
- Optimización en la integración de funcionalidades dependientes de cultivos, tipos de cultivos, jardineras y aspersores.

### Cómo probar
1. Crear un cultivo utilizando el endpoint de creación.
2. Verificar que los IDs se incluyan correctamente en las respuestas de los comandos y queries relacionados.

### Archivos modificados
Cambios realizados en múltiples capas, como `Handlers`, `Responses`, y `Queries` asociados a cultivos, jardineras y aspersores.
