### PR TITLE
feat(api): ✨ Crear endpoint y query handler para obtener lista de cultivos

### DIFF
--- a/src/TechNovaLab.Irrigo.Api/Endpoints/Crops/GetCrops.cs
+++ b/src/TechNovaLab.Irrigo.Api/Endpoints/Crops/GetCrops.cs
@@ -1,21 +1,21 @@
 ﻿using MediatR;
 using TechNovaLab.Irrigo.Api.Extensions;
 using TechNovaLab.Irrigo.Api.Infrastructure;
-using TechNovaLab.Irrigo.Application.Features.CropManagement.GetCropTypes;
+using TechNovaLab.Irrigo.Application.Features.CropManagement.GetCrops;
 using TechNovaLab.Irrigo.Domain.Entities.Users;
 using TechNovaLab.Irrigo.SharedKernel.Core;
 
 namespace TechNovaLab.Irrigo.Api.Endpoints.Crops
 {
-    internal sealed class GetCropTypes : IEndpoint
+    internal sealed class GetCrops : IEndpoint
     {
         public void MapEndpoint(IEndpointRouteBuilder app)
         {
-            app.MapGet("crops/crop-types", async (ISender sender, CancellationToken cancaellationToken) =>
+            app.MapGet("crops", async (ISender sender, CancellationToken cancellationToken) =>
             {
-                var query = new GetCropTypesQuery();
+                var query = new GetCropsQuery();
 
-                Result<IEnumerable<CropTypeResponse>> result = await sender.Send(query, cancaellationToken);
+                Result<IEnumerable<CropResponse>> result = await sender.Send(query, cancellationToken);
 
                 return result.Match(Results.Ok, CustomResults.Problem);
             })

--- a/src/TechNovaLab.Irrigo.Api/Endpoints/Sprinklers/CreateSprinklerGroup.cs
+++ b/src/TechNovaLab.Irrigo.Api/Endpoints/Sprinklers/CreateSprinklerGroup.cs
@@ -20,7 +20,7 @@ namespace TechNovaLab.Irrigo.Api.Endpoints.Sprinklers
 
                 return result.Match(Results.Ok, CustomResults.Problem);
             })
-            .HasRole(Role.Contributor)
+            .HasRole(Role.Member)
             .HasPermission("users:access")
             .WithTags(Tags.Sprinklers);
         }

--- a/src/TechNovaLab.Irrigo.Application/Features/CropManagement/GetCrops/CropResponse.cs
+++ b/src/TechNovaLab.Irrigo.Application/Features/CropManagement/GetCrops/CropResponse.cs
@@ -1,0 +1,14 @@
+﻿namespace TechNovaLab.Irrigo.Application.Features.CropManagement.GetCrops
+{
+    public sealed record CropResponse
+    {
+        public int Id { get; init; }
+        public  Guid PublicId { get; init; }
+        public int CropTypeId { get; init; }
+        public int PlanterId { get; init; }
+        public int SprinklerGroupId { get; init; }
+        public string Name { get; init; } = default!;
+        public int PlantUnits { get; init; }
+        public double DailyWaterConsumption { get; init; }
+    }
+}

--- a/src/TechNovaLab.Irrigo.Application/Features/CropManagement/GetCrops/GetCropsQuery.cs
+++ b/src/TechNovaLab.Irrigo.Application/Features/CropManagement/GetCrops/GetCropsQuery.cs
@@ -1,0 +1,6 @@
+﻿using TechNovaLab.Irrigo.Application.Abstractions.Messaging;
+
+namespace TechNovaLab.Irrigo.Application.Features.CropManagement.GetCrops
+{
+    public sealed record GetCropsQuery: IQuery<IEnumerable<CropResponse>>;
+}

--- a/src/TechNovaLab.Irrigo.Application/Features/CropManagement/GetCrops/GetCropsQueryHandler.cs
+++ b/src/TechNovaLab.Irrigo.Application/Features/CropManagement/GetCrops/GetCropsQueryHandler.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.EntityFrameworkCore;
+using TechNovaLab.Irrigo.Application.Abstractions.Messaging;
+using TechNovaLab.Irrigo.Domain.Entities.Crops;
+using TechNovaLab.Irrigo.Domain.Repositories;
+using TechNovaLab.Irrigo.SharedKernel.Core;
+
+namespace TechNovaLab.Irrigo.Application.Features.CropManagement.GetCrops
+{
+    internal sealed class GetCropsQueryHandler(
+        IRepository repository) : IQueryHandler<GetCropsQuery, IEnumerable<CropResponse>>
+    {
+        public async Task<Result<IEnumerable<CropResponse>>> Handle(GetCropsQuery query, CancellationToken cancellationToken)
+        {
+            List<CropResponse> crops = await repository
+                .Get<Crop>()
+                .Include(x => x.CropType)
+                .Select(x => new CropResponse
+                {
+                    Id = x.Id,
+                    PublicId = x.PublicId,
+                    CropTypeId = x.CropTypeId,
+                    DailyWaterConsumption = x.DailyWaterConsumption,
+                    Name = x.Name,
+                    PlanterId = x.PlanterId,
+                    PlantUnits = x.PlantUnits,
+                    SprinklerGroupId = x.SprinklerGroupId,
+                }).ToListAsync(cancellationToken);
+
+            return crops;
+        }
+    }
+}


### PR DESCRIPTION
### Resumen
- **Funcionalidad añadida**: Endpoint `GetCrops` y query handler para gestionar la lista de cultivos.
- **Correcciones realizadas**: Rol asignado incorrectamente en el endpoint `CreateSprinklerGroup`.

### Detalles técnicos
- **Endpoints modificados**: 
  - `GetCrops` (nuevo).
  - `CreateSprinklerGroup` (rol corregido).
- **Ajustes en el dominio**: Nuevo handler para recuperar datos de cultivos.
- **Archivos afectados**: Varias rutas en `Endpoints` y `Application`.

### Notas adicionales
Este cambio incluye correcciones menores que mejoran la consistencia de roles asignados en la creación de grupos de aspersores.
