### PR TITLE
feat/update-crop: 🌱 Añade caso de uso y endpoint para actualizar cultivos

### DIFF
--- a/src/TechNovaLab.Irrigo.Api/Endpoints/Crops/UpdateCrop.cs
+++ b/src/TechNovaLab.Irrigo.Api/Endpoints/Crops/UpdateCrop.cs
@@ -1,0 +1,40 @@
+﻿using MediatR;
+using TechNovaLab.Irrigo.Api.Extensions;
+using TechNovaLab.Irrigo.Api.Infrastructure;
+using TechNovaLab.Irrigo.Application.Features.CropManagement.UpdateCrop;
+using TechNovaLab.Irrigo.Domain.Entities.Users;
+using TechNovaLab.Irrigo.SharedKernel.Core;
+
+namespace TechNovaLab.Irrigo.Api.Endpoints.Crops
+{
+    internal sealed class UpdateCrop : IEndpoint
+    {
+        public sealed record Request(
+            string Name,
+            int PlantUnits,
+            int CropTypeId,
+            int PlanterId,
+            int SprinklerGroupId);
+
+        public void MapEndpoint(IEndpointRouteBuilder app)
+        {
+            app.MapPut("crops/update-crop/{publicId}", async (Guid publicId, Request request, ISender sender, CancellationToken cancellationToken) =>
+            {
+                var command = new UpdateCropCommand(
+                    publicId,
+                    request.Name,
+                    request.PlantUnits,
+                    request.CropTypeId,
+                    request.PlanterId,
+                    request.SprinklerGroupId);
+
+                Result<CropResponse> result = await sender.Send(command, cancellationToken);
+
+                return result.Match(Results.Ok, CustomResults.Problem);
+            })
+            .HasRole(Role.Member)
+            .HasPermission("users:access")
+            .WithTags(Tags.Crops);
+        }
+    }
+}

--- a/src/TechNovaLab.Irrigo.Application/Features/CropManagement/UpdateCrop/CropResponse.cs
+++ b/src/TechNovaLab.Irrigo.Application/Features/CropManagement/UpdateCrop/CropResponse.cs
@@ -1,0 +1,11 @@
+﻿namespace TechNovaLab.Irrigo.Application.Features.CropManagement.UpdateCrop
+{
+    public sealed record CropResponse(
+        int Id,
+        Guid PublicId,
+        string Name,
+        int PlantUnits,
+        int CropTypeId,
+        int PlanterId,
+        int SprinklerGroupId);
+}

--- a/src/TechNovaLab.Irrigo.Application/Features/CropManagement/UpdateCrop/UpdateCropCommand.cs
+++ b/src/TechNovaLab.Irrigo.Application/Features/CropManagement/UpdateCrop/UpdateCropCommand.cs
@@ -1,0 +1,12 @@
+﻿using TechNovaLab.Irrigo.Application.Abstractions.Messaging;
+
+namespace TechNovaLab.Irrigo.Application.Features.CropManagement.UpdateCrop
+{
+    public sealed record UpdateCropCommand(
+        Guid PublicId,
+        string Name,
+        int PlantUnits,
+        int CropTypeId,
+        int PlanterId,
+        int SprinklerGroupId) : ICommand<CropResponse>;
+}

--- a/src/TechNovaLab.Irrigo.Application/Features/CropManagement/UpdateCrop/UpdateCropCommandHandler.cs
+++ b/src/TechNovaLab.Irrigo.Application/Features/CropManagement/UpdateCrop/UpdateCropCommandHandler.cs
@@ -1,0 +1,70 @@
+﻿using Microsoft.EntityFrameworkCore;
+using TechNovaLab.Irrigo.Application.Abstractions.Data;
+using TechNovaLab.Irrigo.Application.Abstractions.Messaging;
+using TechNovaLab.Irrigo.Application.Services.Crops.Interfaces;
+using TechNovaLab.Irrigo.Domain.Entities.Crops;
+using TechNovaLab.Irrigo.Domain.Errors;
+using TechNovaLab.Irrigo.Domain.Repositories;
+using TechNovaLab.Irrigo.SharedKernel.Core;
+
+namespace TechNovaLab.Irrigo.Application.Features.CropManagement.UpdateCrop
+{
+    internal sealed class UpdateCropCommandHandler(
+        IRepository repository,
+        IUnitOfWork unitOfWork,
+        ICropValidationService validationService) : ICommandHandler<UpdateCropCommand, CropResponse>
+    {
+        public async Task<Result<CropResponse>> Handle(UpdateCropCommand command, CancellationToken cancellationToken)
+        {
+            Crop? crop = await repository
+                .Get<Crop>(x => x.PublicId == command.PublicId)
+                .FirstOrDefaultAsync(cancellationToken);
+
+            if (crop is null)
+            {
+                return Result.Failure<CropResponse>(CropErrors.NotFound(nameof(Crop), command.PublicId));
+            }
+
+            var nameIsUnique = await validationService.ValidateNameIsUniqueAsync(command.Name, cancellationToken);
+            if (nameIsUnique.IsFailure)
+                return Result.Failure<CropResponse>(nameIsUnique.Error);
+
+            if (crop.SprinklerGroupId != command.SprinklerGroupId)
+            {
+                var sprinklerGroupIsAvailable = await validationService.ValidateSprinklerGroupIsAvailableAsync(command.SprinklerGroupId, cancellationToken);
+                if (sprinklerGroupIsAvailable.IsFailure)
+                    return Result.Failure<CropResponse>(sprinklerGroupIsAvailable.Error);
+            }
+
+            if (crop.CropTypeId != command.CropTypeId || crop.PlanterId != command.PlanterId)
+            {
+                var cropTypeInPlanter = await validationService.ValidateCropTypeInPlanterAsync(command.CropTypeId, command.PlanterId, cancellationToken);
+                if(cropTypeInPlanter.IsFailure) 
+                    return Result.Failure<CropResponse>(cropTypeInPlanter.Error);
+            }
+
+            var planterCapacity = await validationService.ValidatePlanterCapacityAsync(command.PlanterId, cancellationToken);
+            if(planterCapacity.IsFailure)
+                return Result.Failure<CropResponse>(planterCapacity.Error);
+
+            crop.Name = command.Name;
+            crop.PlantUnits = command.PlantUnits;
+            crop.CropTypeId = command.CropTypeId;
+            crop.PlanterId = command.PlanterId;
+            crop.SprinklerGroupId = command.SprinklerGroupId;
+
+            repository.Update(crop);
+
+            await unitOfWork.CompleteAsync(cancellationToken);
+
+            return new CropResponse(
+                crop.Id,
+                crop.PublicId,
+                crop.Name,
+                crop.PlantUnits,
+                crop.CropTypeId,
+                crop.PlanterId,
+                crop.SprinklerGroupId);
+        }
+    }
+}

--- a/src/TechNovaLab.Irrigo.Infrastructure/Database/Abstractions/RepositoryBase.cs
+++ b/src/TechNovaLab.Irrigo.Infrastructure/Database/Abstractions/RepositoryBase.cs
@@ -8,7 +8,7 @@ namespace TechNovaLab.Irrigo.Infrastructure.Database.Abstractions
     {
         public DbContextBase Context => context ?? throw new ArgumentNullException(nameof(context));
 
-        public async Task<TEntity> AddAsync<TEntity>(TEntity entity, CancellationToken cancellationToken = default) 
+        public async Task<TEntity> AddAsync<TEntity>(TEntity entity, CancellationToken cancellationToken = default)
             where TEntity : EntityBase
         {
             var result = await Context
@@ -18,7 +18,7 @@ namespace TechNovaLab.Irrigo.Infrastructure.Database.Abstractions
             return result.Entity;
         }
 
-        public async Task<TEntity?> FindAsync<TEntity>(object id, CancellationToken cancellationToken = default) 
+        public async Task<TEntity?> FindAsync<TEntity>(object id, CancellationToken cancellationToken = default)
             where TEntity : EntityBase
         {
             if (id == null)
@@ -35,7 +35,7 @@ namespace TechNovaLab.Irrigo.Infrastructure.Database.Abstractions
             return result;
         }
 
-        public IQueryable<TEntity> Get<TEntity>(Expression<Func<TEntity, bool>>? predicateExpression = null) 
+        public IQueryable<TEntity> Get<TEntity>(Expression<Func<TEntity, bool>>? predicateExpression = null)
             where TEntity : EntityBase
         {
             IQueryable<TEntity> result = Context.Set<TEntity>();
@@ -51,5 +51,14 @@ namespace TechNovaLab.Irrigo.Infrastructure.Database.Abstractions
         public void Remove<TEntity>(TEntity entity) where TEntity : EntityBase => Context
             .Set<TEntity>()
             .Remove(entity);
+
+        public TEntity Update<TEntity>(TEntity entity) where TEntity : EntityBase
+        {
+            ArgumentNullException.ThrowIfNull(entity);
+
+            var result = Context.Set<TEntity>().Update(entity);
+
+            return result.Entity;
+        }
     }
 }

--- a/src/TechNovaLab.Irrigo.SharedKernel/Abstractions/Repositories/IRepositoryBase.cs
+++ b/src/TechNovaLab.Irrigo.SharedKernel/Abstractions/Repositories/IRepositoryBase.cs
@@ -15,5 +15,7 @@ namespace TechNovaLab.Irrigo.SharedKernel.Abstractions.Repositories
             where TEntity : EntityBase;
 
         void Remove<TEntity>(TEntity entity) where TEntity : EntityBase;
+
+        TEntity Update<TEntity>(TEntity entity) where TEntity : EntityBase;
     }
 }


### PR DESCRIPTION
## Descripción
Este PR implementa la funcionalidad para actualizar los datos de un cultivo. Se introduce el caso de uso `UpdateCrop`, su handler, el endpoint en la API y el contrato de respuesta.

Además, fue necesario extender la funcionalidad del repositorio base con un nuevo método `Update`.

## Cambios incluidos
- Nuevo handler `UpdateCropCommandHandler` y su correspondiente `Command` y `Response`.
- Endpoint HTTP en `UpdateCrop.cs`.
- Implementación del método `Update` en `IRepositoryBase` y `RepositoryBase`.

## Notas
Este cambio prepara el sistema para permitir edición de cultivos en el frontend y otros procesos dependientes de esta operación.
